### PR TITLE
US30+US31: TK63 Recent jobs and TK45 Filter jobs on datasource

### DIFF
--- a/App-Challenge/Features/JobList/JobListViewController+UICollectionViewDataSource.swift
+++ b/App-Challenge/Features/JobList/JobListViewController+UICollectionViewDataSource.swift
@@ -86,6 +86,8 @@ extension JobListViewController {
                 do {
                     var jobOffers = try await CloudKitManager.shared.fetchJobOffers()
                     
+                    // Sort by SelectedPositions
+                    jobOffers = SelectedPositions.applyFilter(to: jobOffers)
                     
                     // Order by creationData
                     jobOffers.sort {

--- a/App-Challenge/Features/JobList/JobListViewController+UICollectionViewDataSource.swift
+++ b/App-Challenge/Features/JobList/JobListViewController+UICollectionViewDataSource.swift
@@ -84,7 +84,13 @@ extension JobListViewController {
         CloudKitManager.databaseQueue.async {
             Task {
                 do {
-                    let jobOffers = try await CloudKitManager.shared.fetchJobOffers()
+                    var jobOffers = try await CloudKitManager.shared.fetchJobOffers()
+                    
+                    
+                    // Order by creationData
+                    jobOffers.sort {
+                        $0.creationDate > $1.creationDate
+                    }
 
                     DispatchQueue.main.async {
                         self.listedJobOffers = jobOffers


### PR DESCRIPTION
## Relates to:

### US30 - Prioritize recent job offers

- **TK63** – Sort the data source by job posting date (or create a CK function to fetch in order).

### US31 - Filter job offers by position

- **TK45** – Filter job offers by selected position/role (at the DataSource level).

## Notes or Known Issues

- Filtering directly in the data source isn't optimal. An issue (#39) has been created for future optimization.