### PR TITLE
Add async method to create mock data if needed in CloudKitManager

### DIFF
--- a/Freela-onTap/App/SceneDelegate.swift
+++ b/Freela-onTap/App/SceneDelegate.swift
@@ -23,16 +23,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         
+        Task {
+            await CloudKitManager.shared.createMockDataIfNeeded()
+        }
+        
         window = UIWindow(windowScene: windowScene)
-
         
         // Force light mode
         window?.overrideUserInterfaceStyle = .light
         
         // Set window root contoller
-//        window?.rootViewController = UINavigationController(rootViewController: TabBarController())
         window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
-//        window?.rootViewController = UINavigationController(rootViewController: Onboarding2ViewController())
         window?.makeKeyAndVisible()
     }
 

--- a/Freela-onTap/Persistence/CloudKitManager/CloudKitManager+MockData.swift
+++ b/Freela-onTap/Persistence/CloudKitManager/CloudKitManager+MockData.swift
@@ -9,6 +9,17 @@ import CloudKit
 import Foundation
 
 extension CloudKitManager {
+    
+    func createMockDataIfNeeded() async {
+        let companyList = try? await fetchAllCompanies()
+        
+        guard let _ = companyList?.first else {
+            try? await addMockCompaniesAndJobs()
+            print("Mock data added successfully!")
+            return
+        }
+    }
+    
     func deleteAllMockData() async throws {
         try await throwIfICloudNotAvailable()
         


### PR DESCRIPTION
## Description

When published on the TestFlight, the mock date will need to be readied, show now is a function that check if the database is empty and then adds the mock data